### PR TITLE
Create Archlinux_Caddy_Install.sh

### DIFF
--- a/Server.Installer/Resources/Archlinux_Caddy_Install.sh
+++ b/Server.Installer/Resources/Archlinux_Caddy_Install.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+echo "Thanks for trying Remotely!"
+echo
+
+Args=( "$@" )
+ArgLength=${#Args[@]}
+
+for (( i=0; i<${ArgLength}; i+=2 ));
+do
+    if [ "${Args[$i]}" = "--host" ]; then
+        HostName="${Args[$i+1]}"
+    elif [ "${Args[$i]}" = "--approot" ]; then
+        AppRoot="${Args[$i+1]}"
+    fi
+done
+
+if [ -z "$AppRoot" ]; then
+    read -p "Enter path where the Remotely server files should be installed (typically /var/www/remotely): " AppRoot
+    if [ -z "$AppRoot" ]; then
+        AppRoot="/var/www/remotely"
+    fi
+fi
+
+if [ -z "$HostName" ]; then
+    read -p "Enter server host (e.g. remotely.yourdomainname.com): " HostName
+fi
+
+chmod +x "$AppRoot/Remotely_Server"
+
+echo "Using $AppRoot as the Remotely website's content directory."
+
+# Install .NET Core Runtime.
+pacman -Sy dotnet-runtime dotnet-host
+
+# Install other prerequisites.
+pacman -Sy unzip acl glibc libgdiplus
+
+# Install Caddy
+pacman -Sy caddy
+
+# Configure Caddy
+caddyConfig="
+$HostName {
+    reverse_proxy 127.0.0.1:5000
+}
+"
+
+echo "$caddyConfig" >> /etc/caddy/conf.d/Caddyfile
+
+# Create Remotely service.
+
+serviceConfig="[Unit]
+Description=Remotely Server
+
+[Service]
+WorkingDirectory=$AppRoot
+ExecStart=/usr/bin/dotnet $AppRoot/Remotely_Server.dll
+Restart=always
+# Restart service after 10 seconds if the dotnet service crashes:
+RestartSec=10
+SyslogIdentifier=remotely
+Environment=ASPNETCORE_ENVIRONMENT=Production
+Environment=DOTNET_PRINT_TELEMETRY_MESSAGE=false
+
+[Install]
+WantedBy=multi-user.target"
+
+echo "$serviceConfig" > /etc/systemd/system/remotely.service
+
+
+# Enable service.
+systemctl enable remotely.service
+# Start service.
+systemctl start remotely.service
+
+
+# Start caddy
+systemctl start caddy
+# Reload caddy to update config
+systemctl reload caddy


### PR DESCRIPTION
Installation script for Arch-based distros. Added correct names of packages in Arch and removed unnecessary.

---

Please read the following.  Do not delete below this line.

---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to me (Jared Goodwin) so that I retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that I'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Jared Goodwin, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
